### PR TITLE
write migration to backfill all null values of name

### DIFF
--- a/db/migrations/20210614223115_backfill_movies_name.js
+++ b/db/migrations/20210614223115_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = function (Knex) {
+  return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = function (Knex, Promise) {
+  return Promise.resolve();
+};


### PR DESCRIPTION
In the database, both name and title should get populated, wrote a migration to backfill all the null values of name.